### PR TITLE
Fix scaler path and add model directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ This project leverages several key libraries:
 ### Summary
 
 This project combines multiple decision tree-based approaches to optimize prediction of in-hospital mortality, providing insight into which clinical features most significantly contribute to patient outcomes.
+
+### Model Artifacts
+
+The Streamlit app expects trained TensorFlow models in the directories
+`model_rd/` (Random Forest) and `model_gbdt/` (Gradient Boosted Trees).
+These folders are provided empty in the repository to keep its size small.
+
+To recreate the models:
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Load `221.csv` and `230.csv`, concatenate them, and split into features
+   and labels.
+3. Fit a `StandardScaler` on the feature columns and save it using
+   `joblib.dump(scaler, "scaler_decision_trees.joblib")`.
+4. Train a `tfdf.keras.RandomForestModel` and save it with
+   `tf.saved_model.save(model_rd, "model_rd")`.
+5. Train a `tfdf.keras.GradientBoostedTreesModel` and save it with
+   `tf.saved_model.save(model_gbdt, "model_gbdt")`.
+
+Once trained, place the resulting `model_rd/` and `model_gbdt/` directories
+in the repository root so `fin.py` can load them.

--- a/fin.py
+++ b/fin.py
@@ -8,8 +8,8 @@ import joblib
 model_rd = tf.saved_model.load("model_rd")  # Load Random Forest model
 model_gbdt = tf.saved_model.load("model_gbdt")  # Load GBDT model
 
-# Load the scaler
-scaler = joblib.load("/Users/rohit/Desktop/Decision-Trees/models/scaler_decision_trees.joblib")  # Ensure this path is correct
+# Load the scaler from the repository
+scaler = joblib.load("scaler_decision_trees.joblib")
 
 # Streamlit app layout
 st.title("In-Hospital Mortality Prediction")

--- a/model_gbdt/README.md
+++ b/model_gbdt/README.md
@@ -1,0 +1,1 @@
+This directory should contain the TensorFlow SavedModel for the Gradient Boosted Trees model.

--- a/model_rd/README.md
+++ b/model_rd/README.md
@@ -1,0 +1,1 @@
+This directory should contain the TensorFlow SavedModel for the Random Forest model.


### PR DESCRIPTION
## Summary
- load scaler using a relative path in `fin.py`
- create placeholder model directories for `model_rd` and `model_gbdt`
- document how to train and save models in README

## Testing
- `python -m py_compile fin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414e89e40483278504a875a19950ea